### PR TITLE
Set final class to enum class.

### DIFF
--- a/src/Commands/stubs/enum.stub
+++ b/src/Commands/stubs/enum.stub
@@ -2,6 +2,6 @@
 
 namespace DummyNamespace;
 
-final class DummyClass
+enum DummyClass
 {
 }


### PR DESCRIPTION
Because Laravel 9 support Enums in the routing and models. The final class is outdated in my opinion. That why i write this PR. To keep it more updated.