### PR TITLE
Add config parameter to change root folder of domains.

### DIFF
--- a/config/domain-commands.php
+++ b/config/domain-commands.php
@@ -10,6 +10,13 @@ return [
     'default_namespace' => 'Shared',
 
     /*
+     * The directory containing the domains
+     *
+     * Example: src
+     */
+    'domain_root' => 'app',
+
+    /*
      * Overwrite the default stubs for each domain class type.
      * It should be a valid path to your custom stub file.
      * When set to `null`, the default stub is used.

--- a/src/Commands/DomainGeneratorCommand.php
+++ b/src/Commands/DomainGeneratorCommand.php
@@ -35,7 +35,7 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Commands/ModelCommand.php
+++ b/src/Commands/ModelCommand.php
@@ -46,7 +46,7 @@ class ModelCommand extends ModelMakeCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Commands/ObserverCommand.php
+++ b/src/Commands/ObserverCommand.php
@@ -46,7 +46,7 @@ class ObserverCommand extends ObserverMakeCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Commands/PolicyCommand.php
+++ b/src/Commands/PolicyCommand.php
@@ -46,7 +46,7 @@ class PolicyCommand extends PolicyMakeCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Commands/RuleCommand.php
+++ b/src/Commands/RuleCommand.php
@@ -46,7 +46,7 @@ class RuleCommand extends RuleMakeCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**


### PR DESCRIPTION
Hey signifly team,

we also use the domain pattern that Brent described in his book and I wanted to create commands to generate all the entities with artisan myself, but I discovered your package first.

It would need only one change as we moved our code out of the standard Laravel app directory into a src folder (which is also a part of Brents book if I remember correctly).

I saw this PR https://github.com/signifly/laravel-domain-commands/pull/2. As you said that it could be beneficial, I extracted the config part into this PR and hope you consider merging it.

Kind regards,

Michael

PS: I tried to add tests to the package but I couldn't find a way to make it work. Orchestra is throwing errors in the console and I get an error when extending the TestCase from Orchestra. I could not find good resources to make it work in short time.

Errors were

```
During inheritance of ArrayAccess: Uncaught ErrorException: Return type of Illuminate\Http\Request::offsetExists($offset) should either be   
  compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily sup  
  press the notice 
```

```
'Signifly\Console\Tests\TestCase' does not implement methods 'call', 'createApplication', 'be', 'seed', 'artisan'
```