### PR TITLE
Add new command to generate test files for actions

### DIFF
--- a/config/domain-commands.php
+++ b/config/domain-commands.php
@@ -22,14 +22,17 @@ return [
      * When set to `null`, the default stub is used.
      */
     'stubs' => [
-        'action'    => null,
-        'dto'       => null,
-        'enum'      => null,
-        'event'     => null,
-        'model'     => null,
-        'observer'  => null,
-        'policy'    => null,
-        'rule'      => null,
+        'action' => null,
+        'dto' => null,
+        'enum' => null,
+        'event' => null,
+        'model' => null,
+        'observer' => null,
+        'policy' => null,
+        'rule' => null,
+        'tests' => [
+            'action' => null,
+        ],
     ],
 
 ];

--- a/config/domain-commands.php
+++ b/config/domain-commands.php
@@ -10,6 +10,13 @@ return [
     'default_namespace' => 'Shared',
 
     /*
+     * The directory containing the domains
+     *
+     * Example: src
+     */
+    'domain_root' => 'app',
+
+    /*
      * Overwrite the default stubs for each domain class type.
      * It should be a valid path to your custom stub file.
      * When set to `null`, the default stub is used.

--- a/src/Commands/DomainGeneratorCommand.php
+++ b/src/Commands/DomainGeneratorCommand.php
@@ -35,7 +35,7 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Commands/ModelCommand.php
+++ b/src/Commands/ModelCommand.php
@@ -46,7 +46,7 @@ class ModelCommand extends ModelMakeCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Commands/ObserverCommand.php
+++ b/src/Commands/ObserverCommand.php
@@ -46,7 +46,7 @@ class ObserverCommand extends ObserverMakeCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Commands/PolicyCommand.php
+++ b/src/Commands/PolicyCommand.php
@@ -46,7 +46,7 @@ class PolicyCommand extends PolicyMakeCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Commands/RuleCommand.php
+++ b/src/Commands/RuleCommand.php
@@ -46,7 +46,7 @@ class RuleCommand extends RuleMakeCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/app/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.config('domain-commands.domain_root').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Commands/TestActionCommand.php
+++ b/src/Commands/TestActionCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Signifly\Console\Commands;
+
+class TestActionCommand extends TestDomainGeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'domain:test-action';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a test for an action for a given domain';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Action';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        $stubPath = config('domain-commands.stubs.tests.action');
+
+        if (! is_null($stubPath) && is_string($stubPath)) {
+            return $stubPath;
+        }
+
+        return __DIR__.'/stubs/tests/action.stub';
+    }
+}

--- a/src/Commands/TestActionCommand.php
+++ b/src/Commands/TestActionCommand.php
@@ -9,7 +9,7 @@ class TestActionCommand extends TestDomainGeneratorCommand
      *
      * @var string
      */
-    protected $name = 'domain:test-action';
+    protected $name = 'domain:action-test';
 
     /**
      * The console command description.

--- a/src/Commands/TestDomainGeneratorCommand.php
+++ b/src/Commands/TestDomainGeneratorCommand.php
@@ -35,7 +35,7 @@ abstract class TestDomainGeneratorCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().'/'.lcfirst(str_replace('\\', '/', $name)).'.php';
     }
 
     /**

--- a/src/Commands/TestDomainGeneratorCommand.php
+++ b/src/Commands/TestDomainGeneratorCommand.php
@@ -45,7 +45,7 @@ abstract class TestDomainGeneratorCommand extends GeneratorCommand
      */
     protected function rootNamespace()
     {
-        return 'Tests\\Domain\\';
+        return 'Domain\\';
     }
 
     /**

--- a/src/Commands/TestDomainGeneratorCommand.php
+++ b/src/Commands/TestDomainGeneratorCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Signifly\Console\Commands;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class TestDomainGeneratorCommand extends GeneratorCommand
+{
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        $type = Str::plural($this->type);
+
+        if ($domain = $this->option('domain')) {
+            return "{$rootNamespace}\\{$domain}\\{$type}";
+        }
+
+        $defaultNamespace = config('domain-commands.default_namespace');
+
+        return "{$rootNamespace}\\{$defaultNamespace}\\{$type}";
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return $this->laravel->basePath().'/tests/'.str_replace('\\', '/', $name).'.php';
+    }
+
+    /**
+     * Get the root namespace for the class.
+     *
+     * @return string
+     */
+    protected function rootNamespace()
+    {
+        return 'Tests\\Domain\\';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['domain', 'd', InputOption::VALUE_REQUIRED, 'Set the domain name'],
+        ];
+    }
+}

--- a/src/Commands/TestDomainGeneratorCommand.php
+++ b/src/Commands/TestDomainGeneratorCommand.php
@@ -35,7 +35,7 @@ abstract class TestDomainGeneratorCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->basePath().'/tests/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->basePath().str_replace('\\', '/', $name).'.php';
     }
 
     /**
@@ -45,7 +45,7 @@ abstract class TestDomainGeneratorCommand extends GeneratorCommand
      */
     protected function rootNamespace()
     {
-        return 'Domain\\';
+        return 'Tests\\Domain\\';
     }
 
     /**

--- a/src/Commands/stubs/tests/action.stub
+++ b/src/Commands/stubs/tests/action.stub
@@ -2,10 +2,10 @@
 
 namespace DummyNamespace;
 
-final class DummyClass
+class DummyClass
 {
     /** @test */
-    public function test()
+    public function it_()
     {
         //
     }

--- a/src/Commands/stubs/tests/action.stub
+++ b/src/Commands/stubs/tests/action.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace DummyNamespace;
+
+final class DummyClass
+{
+    /** @test */
+    public function test()
+    {
+        //
+    }
+}

--- a/src/DomainServiceProvider.php
+++ b/src/DomainServiceProvider.php
@@ -11,6 +11,7 @@ use Signifly\Console\Commands\ModelCommand;
 use Signifly\Console\Commands\ActionCommand;
 use Signifly\Console\Commands\PolicyCommand;
 use Signifly\Console\Commands\ObserverCommand;
+use Signifly\Console\Commands\TestActionCommand;
 
 class DomainServiceProvider extends ServiceProvider
 {
@@ -30,6 +31,7 @@ class DomainServiceProvider extends ServiceProvider
                 ObserverCommand::class,
                 PolicyCommand::class,
                 RuleCommand::class,
+                TestActionCommand::class,
             ]);
         }
 


### PR DESCRIPTION
We used DomainGeneratorCommand as a blueprint for the test creation. DTO command will come next.

Allows to create tests for actions with an artisan command. Makes it easier to create test cases at the correct location to increase consistency in test creation.

We recommend to create further test methods with a VSCode snippet. You can add user snippets for php files when searching for snippets in the preferences.

```
  "Test Method": {
    "prefix": "test",
    "body": ["/** @test */", "public function $1()", "{", " $3", "}"]
  },
```

Sorry, I branched from the master that has the config changes. 